### PR TITLE
Change displayed name to "My Reaction When" and tidy slug

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,8 +1,8 @@
 {
   "expo": {
-    "name": "mrw-app",
+    "name": "My Reaction When",
     "description": "A really fun party game!",
-    "slug": "mrw-app",
+    "slug": "mrw",
     "privacy": "public",
     "sdkVersion": "23.0.0",
     "version": "0.2.4",


### PR DESCRIPTION
- Makes the displayed name that people see on expo.io be "My Reaction When" instead of mrw-app.
- Changes the slug from mrw-app to mrw. Republishing will actually create a new project because the slug is part of the unique identifier, which means the old push notification tokens (for mrw-app) need to be sent separately from the new ones (for mrw). But since this game is still new, earlier would be better than later. If you don't want this change I'll revert it.